### PR TITLE
Refresh rook documentation

### DIFF
--- a/docs/installation-java.md
+++ b/docs/installation-java.md
@@ -5,7 +5,7 @@ title: Java Rook Setup
 
 ## Introduction
 
-The Node.js Rook provides the ability to fetch debug data from a running application in real time.
+The Java Rook provides the ability to fetch debug data from a running application in real time.
 It is deployed by deploying the [Rook SDK](https://mvnrepository.com/artifact/com.rookout/rook).
 
 It can be download directly to the target system by running the following command:
@@ -25,19 +25,19 @@ dependencies {
 ## Basic Setup
 
 Setup the Rookout token in your environment:
-```javascript
+```bash
 // Export your token as an environment variable
 $ export ROOKOUT_TOKEN=[Your Rookout Token]
 ```
 
 Tag your environment:
-```javascript
+```bash
 // Use a set of semicolon separated values to identify specific deployments and configurations
 $ export ROOKOUT_TAGS=[;;;]
 ```
 
 Add the Java agent to your application:
-```javascript
+```bash
 $ export JAVA_OPTIONS="$JAVA_OPTIONS -javaagent:(pwd)/rook.jar"
 ```
 
@@ -60,7 +60,7 @@ Unlike Node and Python applications, most JVM applications do not include their 
 In order to shut off the warning and gain the value of source verification, you should include your source files within your JAR/WAR/EAR library.
 
 For Gradle, use the following snippet:
-```javascript
+```java
 jar {
    from sourceSets.main.allSource
 }
@@ -93,16 +93,4 @@ For using Java under a Serverless/PaaS environment, the following must be taken 
 - For Serverless applications, you must call the Rookout API on every endpoint and flush at your discretion.
 - In some Serverless environments, the tools.jar library is missing and must be included within your package as well.
 
-## Examples
-
-Check out the following deployment examples:
-
-- [Using Docker-Compose](https://github.com/Rookout/deployment-examples/tree/master/java-docker-compose)
-- [Using Gradle](https://github.com/Rookout/deployment-examples/tree/master/java-gradle)
-- [Using Maven](https://github.com/Rookout/deployment-examples/tree/master/java-maven)
-- [AWS Elastic Beanstalk](https://github.com/Rookout/deployment-examples/tree/master/java-aws-elasticbeanstalk)
-- [Tomcat on AWS Elastic Beanstalk](https://github.com/Rookout/deployment-examples/tree/master/java-tomcat-aws-elasticbeanstalk)
-- [Oracle WebLogic](https://github.com/Rookout/deployment-examples/tree/master/java-weblogic)
-- [JBoss WildFly](https://github.com/Rookout/deployment-examples/tree/master/java-wildfly-docker-agentless)
-
-Or visit [our GitHub repository](https://github.com/Rookout/deployment-examples) for more deployment examples.
+For additional environments, check out our [deployment examples page](https://github.com/Rookout/deployment-examples).

--- a/docs/installation-node.md
+++ b/docs/installation-node.md
@@ -3,11 +3,33 @@ id: installation-node
 title: Node Rook Setup
 ---
 
-The Node.js Rook is an npm package that runs inside the user's application.  
-This allows Rookout to remotely inspect the state of the process.
+## Introduction
 
-## Pre-requisites:
-- *Node.js* ([download here](https://nodejs.org/))
+The Node.js Rook provides the ability to fetch debug data from a running application in real time.
+It is deployed by deploying the [Rook SDK](https://www.npmjs.com/package/rookout).
+It can easily be installed by running the following command:
+```bash
+$ npm install --save rookout
+```
+
+## Basic setup
+
+Setup the Rookout token in your environment:
+```javascript
+// Export your token as an environment variable
+$ export ROOKOUT_TOKEN=[Your Rookout Token]
+```
+
+Tag your environment:
+```javascript
+// Use a set of semicolon separated values to identify specific deployments and configurations
+$ export ROOKOUT_TAGS=[;;;]
+```
+
+Import the Rook within your application:
+```javascript
+const rook = require('rookout/auto_start');
+```
 
 ## Supported Versions
 
@@ -15,42 +37,39 @@ This allows Rookout to remotely inspect the state of the process.
 | ------------------ | -------------- |
 | **Node**           | 4.3+, 6, 8, 10  |
 
-## Setup guide
+**Note:** Rookout only supports LTS (Long Time Support) versions of Node.js.
 
-1. Add our npm package to your package.json:  
-    ```bash 
-    $ npm install --save rookout
-    ```
-    
-1. Require the package in your app's entry-point file:
-    ```javascript
-    const rook = require('rookout/auto_start');
-    ```
+## Source Code Detection
+Source detection functionality is currently not supported for Node.js.
 
-1. Configure the required environment variables:
+## Dependencies 
 
-    ```bash
-    $ export ROOKOUT_TOKEN=[Your Rookout Token]
-    $ export ROOKOUT_ROOK_TAGS=[List of semicolon ; separated values to identify this app instance]
-    ```
+Rookout SDK contains third-party native extensions. For most common interpreter and OS configurations, pre-built binaries are provided. For other configurations, a build environment is needed to successfully install Rookout.
 
-    <details>
-    <summary>_Installing the npm package using a proxy_</summary>
+Please install the appropriate build tools for your environment:
 
-    Unix:
-    ```bash
-    export HTTPS_PROXY=https://mypro.xy:1234 && npm install --save rookout
-    ```
-    Windows:
-    ```bash
-    set HTTPS_PROXY=https://mypro.xy:1234 && npm install --save rookout
-    ```
+1. Mac
+    - $ xcode-select --install
+2. Debian based
+    - $ apt-get update -q && apt-get install -qy
+3. Fedora based
+    - $ yum install -qy
+4. Alpine
+    - $ apk update && apk add
 
-    </details>
-    
-Once your application is deployed, navigate to the Rookout App Instances page to make sure it is available for debugging.
-For advanced Rook configuration, check out the [Rook Configuration page](rooks-config.md).<br/>
-If you encounter any issues, check out our [Troubleshooting section](troubleshooting-rooks.md).
+## Serverless and PaaS
+If you are running your application on a Serverless or PaaS (Platform as a Service), you must build your package in an environment similar to those used in production. 
+If you are running on a Windows or Mac machine (or using an incompatible Linux distribution) you may encounter some issues here.
+
+Many Serverless frameworks (such as AWS sam) has built-in support for it and will work out of the box.
+
+If you need to set up your own build, we recommend using Docker, with a command line such as:
+
+```bash
+$ docker run -it -v `pwd`:`pwd` -w `pwd` node:8 pip install -t lib
+```
+
+For more information check out this blog post: https://www.rookout.com/3_min_hack_for_building_local_native_extensions/
 
 ## Examples
 
@@ -64,4 +83,4 @@ Check out the following deployment examples:
 - [IBM Cloud Functions](https://github.com/Rookout/deployment-examples/tree/master/node-ibm-cloud-functions)
 - [Electron](https://github.com/Rookout/deployment-examples/tree/master/node-electron)
 
-Or visit [our GitHub repository](https://github.com/Rookout/deployment-examples) for more.
+Or visit [our GitHub repository](https://github.com/Rookout/deployment-examples) for more deployment examples.

--- a/docs/installation-node.md
+++ b/docs/installation-node.md
@@ -15,13 +15,13 @@ $ npm install --save rookout
 ## Basic setup
 
 Setup the Rookout token in your environment:
-```javascript
+```bash
 // Export your token as an environment variable
 $ export ROOKOUT_TOKEN=[Your Rookout Token]
 ```
 
 Tag your environment:
-```javascript
+```bash
 // Use a set of semicolon separated values to identify specific deployments and configurations
 $ export ROOKOUT_TAGS=[;;;]
 ```
@@ -39,23 +39,8 @@ const rook = require('rookout/auto_start');
 
 **Note:** Rookout only supports LTS (Long Time Support) versions of Node.js.
 
-## Source Code Detection
-Source detection functionality is currently not supported for Node.js.
-
-## Dependencies 
-
-Rookout SDK contains third-party native extensions. For most common interpreter and OS configurations, pre-built binaries are provided. For other configurations, a build environment is needed to successfully install Rookout.
-
-Please install the appropriate build tools for your environment:
-
-1. Mac
-    - $ xcode-select --install
-2. Debian based
-    - $ apt-get update -q && apt-get install -qy
-3. Fedora based
-    - $ yum install -qy
-4. Alpine
-    - $ apk update && apk add
+## Source Commit Detection
+Source commit detection functionality is currently not supported for Node.js.
 
 ## Serverless and PaaS
 If you are running your application on a Serverless or PaaS (Platform as a Service), you must build your package in an environment similar to those used in production. 
@@ -65,22 +50,8 @@ Many Serverless frameworks (such as AWS sam) has built-in support for it and wil
 
 If you need to set up your own build, we recommend using Docker, with a command line such as:
 
-```bash
-$ docker run -it -v `pwd`:`pwd` -w `pwd` node:8 pip install -t lib
-```
+docker run -it -v `pwd`:`pwd` -w `pwd` node:8 pip install -t lib
 
 For more information check out this blog post: https://www.rookout.com/3_min_hack_for_building_local_native_extensions/
 
-## Examples
-
-Check out the following deployment examples:
-
-- [Google AppEngine](https://github.com/Rookout/deployment-examples/tree/master/node-app-engine-flex)
-- [AWS Elastic Container Service](https://github.com/Rookout/deployment-examples/tree/master/node-aws-ecs)
-- [AWS Elastic Beanstalk](https://github.com/Rookout/deployment-examples/tree/master/node-aws-elasticbeanstalk)
-- [Using TypeScript](https://github.com/Rookout/deployment-examples/tree/master/node-typescript)
-- [AWS Lambda](https://github.com/Rookout/deployment-examples/tree/master/node-aws-lambda)
-- [IBM Cloud Functions](https://github.com/Rookout/deployment-examples/tree/master/node-ibm-cloud-functions)
-- [Electron](https://github.com/Rookout/deployment-examples/tree/master/node-electron)
-
-Or visit [our GitHub repository](https://github.com/Rookout/deployment-examples) for more deployment examples.
+For additional environments, check out our [deployment examples page](https://github.com/Rookout/deployment-examples).

--- a/docs/installation-python.md
+++ b/docs/installation-python.md
@@ -22,7 +22,7 @@ $ export ROOKOUT_TOKEN=[Your Rookout Token]
 
 Tag your environment:
 ```javascript
-# Export your token as an environment variable
+# Use a set of semicolon separated values to identify specific deployments and configurations
 $ export ROOKOUT_TAGS=[;;;]
 ```
 
@@ -43,6 +43,8 @@ The reason for this is that it’s impossible to know in Python if a module is f
 | ------------------ | ------------------ |
 | **CPython**        | 2.7, 3.5, 3.6, 3.7 |
 | **PyPy**           | 6.0.0              |
+
+***Note:*** We recommend avoiding production deployment for Windows based apps.
 
 ## Source Commit Detection
 

--- a/docs/installation-python.md
+++ b/docs/installation-python.md
@@ -3,62 +3,46 @@ id: installation-python
 title: Python Rook Setup
 ---
 
-The Python Rook is a python package that runs inside the user's application.  
-This allows Rookout to remotely inspect the state of the process.
+## Introduction
 
-## Pre-requisites
-- *Python* ([download here](https://www.python.org/downloads/))
-- *pip* ([download here](https://pip.pypa.io/en/stable/installing/))
-- *virtualenv* ([documentation](https://virtualenv.pypa.io/en/stable/installation/))
+The Python Rook provides the ability to fetch debug data from a running application in real time.
+It is deployed by deploying the [Rook SDK](https://pypi.org/project/rook/).
+It can easily be installed by running the following command:
+```bash
+    $ pip install rook
+```
+
+## Basic setup
+
+Setup the Rookout token in your environment:
+```javascript
+# Export your token as an environment variable
+$ export ROOKOUT_TOKEN=[Your Rookout Token]
+```
+
+Tag your environment:
+```javascript
+# Export your token as an environment variable
+$ export ROOKOUT_TAGS=[;;;]
+```
+
+Import the Rook within your application:
+```javascript
+# Import the package in your app's entry-point file, just before it starts
+from rook import auto_start
+if __name__ == "__main__":
+    # Your program starts here :)
+```
+
+The Rook should be imported as late as possible within the application.
+The reason for this is that it’s impossible to know in Python if a module is fully loaded and if all classes within it have been defined. Unlike JS and it’s hoisting concept, classes in Python are created when the interpreter first executes them. If we’ll see a partially loaded module and failed to set a breakpoint in it (because the class has not been defined yet) setting the breakpoint will fail and the user will receive an error.
 
 ## Supported Python versions
 
-| Implementation     | Language   | Versions           |
-| ------------------ | ---------- | ------------------ |
-| **CPython**        | 2          | 2.7                |
-| **CPython**        | 3          | 3.5, 3.5, 3.6, 3.7 |
-| **PyPy**           | 2          | 6.0.0       |
-
-## Setup guide
-
-1. Create and activate a new virtual environment :
-    ```bash
-    $ virtualenv virtualenv
-    $ source virtualenv/bin/activate
-    ```
-
-1. Install the Rookout pypi package :  
-    ```bash
-    $ pip install rook
-    ```
-
-1. Import the package in your app's entry-point file :  
-    ```python
-    from rook import auto_start
-    ```
-
-1. Configure the required environment variables:
-
-    ```bash
-    $ export ROOKOUT_TOKEN=[Your Rookout Token]
-    $ export ROOKOUT_ROOK_TAGS=[List of semicolon ; separated values to identify this app instance]
-    ```
-
-    <details>
-    <summary>_Installing the Rookout pypi package using a proxy_</summary>
-    Unix:
-    ```bash
-    export HTTPS_PROXY=https://mypro.xy:1234 && pip install rook
-    ```
-    Windows:
-    ```bash
-    set HTTPS_PROXY=https://mypro.xy:1234 && pip install rook
-    ```
-    </details>
-
-    Once your application is deployed, navigate to the Rookout App Instances page to make sure it is available for debugging.
-    For advanced Rook configuration, check out the [Rook Configuration page](rooks-config.md).<br/>
-    If you encounter any issues, check out our [Troubleshooting section](troubleshooting-rooks.md).
+| Implementation     | Versions           |
+| ------------------ | ------------------ |
+| **CPython**        | 2.7, 3.5, 3.6, 3.7 |
+| **PyPy**           | 6.0.0              |
 
 ## Additional info
 

--- a/docs/installation-python.md
+++ b/docs/installation-python.md
@@ -15,19 +15,19 @@ It can easily be installed by running the following command:
 ## Basic setup
 
 Setup the Rookout token in your environment:
-```javascript
+```bash
 # Export your token as an environment variable
 $ export ROOKOUT_TOKEN=[Your Rookout Token]
 ```
 
 Tag your environment:
-```javascript
+```bash
 # Use a set of semicolon separated values to identify specific deployments and configurations
 $ export ROOKOUT_TAGS=[;;;]
 ```
 
 Import the Rook within your application:
-```javascript
+```python
 # Import the package in your app's entry-point file, just before it starts
 from rook import auto_start
 if __name__ == "__main__":
@@ -93,15 +93,4 @@ If you need to set up your own build, we recommend using Docker, with a command 
 
 For more information check out this blog post: https://www.rookout.com/3_min_hack_for_building_local_native_extensions/
 
-
-## Examples
-
-Check out the following deployment examples:
-
-- [Django](https://github.com/Rookout/deployment-examples/tree/master/python-django)
-- [Kubernetes](https://github.com/Rookout/deployment-examples/tree/master/python-kubernetes)
-- [AWS Lambda](https://github.com/Rookout/deployment-examples/tree/master/python-aws-lambda)
-- [AWS Lambda + Chalice](https://github.com/Rookout/deployment-examples/tree/master/python-aws-chalice)
-- [AWS Lambda + serverless framework ](https://github.com/Rookout/deployment-examples/tree/master/python-aws-serverlessframework)
-
-Or visit [our GitHub repository](https://github.com/Rookout/deployment-examples) for more deployment examples.
+For additional environments, check out our [deployment examples page](https://github.com/Rookout/deployment-examples).

--- a/docs/installation-python.md
+++ b/docs/installation-python.md
@@ -44,29 +44,53 @@ The reason for this is that it’s impossible to know in Python if a module is f
 | **CPython**        | 2.7, 3.5, 3.6, 3.7 |
 | **PyPy**           | 6.0.0              |
 
-## Additional info
+## Source Commit Detection
 
-- The Python Rook needs to be installed within the application's virtualenv.
-- Old installation tools may cause issues. Attempt to upgrade pip and remove distribute (deprecated, only if exists):
-    - `pip install -U pip`
-    - `pip uninstall distribute`
-- Installation requires compiling some Python extensions on the fly. The following packages are required:
-  - apt
-    - `$ apt-get update -q`
-    - `$ apt-get install -qy g++ python-dev`
-  - yum
-    - `$ yum install -qy gcc-c++ python-devel`
-  - apk
+The Python Rook supports detecting the existing source code commit in the following methods, in descending order of priority:
+1. If the environment variable “ROOKOUT_COMMIT” exists, use it.
+2. If the environment variable “ROOKOUT_GIT” exists, search for the configuration of the “.git” folder and use its head.
+3. If the main application is running from within a Git repository, use its head. 
 
-For more control over the Python Rook initialization, check out this [page](rooks-python_interface.md).
+## Dependancies
 
-## Source Code Version
+The Rookout Python SDK contains native extensions. For most common interpreter and OS configurations, pre-built binaries are provided. For other configurations, a build environment is needed to successfully install Rookout.
 
-The Python Rook will attempt to determine the current Git commit the application is based off, and will report it.
-The resolution takes place in the following steps:
-1. If there's an environment variable named 'ROOKOUT_COMMIT' use it.
-1. If there's an environment variable named 'ROOKOUT_GIT' get the current Git head from that path.
-1. If the application is running from a Git repo, get the current Git head for that repo.   
+If you encounter an error similar to the following example, be sure to install the environment specific build tools specified below:
+
+```bash
+    Could not find <Python.h>. This could mean the following:
+      * You're on Ubuntu and haven't run `apt-get install python-dev`.
+      * You're on RHEL/Fedora and haven't run `yum install python-devel` or
+        `dnf install python-devel` (make sure you also have redhat-rpm-config
+        installed)
+      * You're on Mac OS X and the usual Python framework was somehow corrupted
+        (check your environment variables or try re-installing?)
+      * You're on Windows and your Python installation was somehow corrupted
+        (check your environment variables or try re-installing?)
+```
+1. Mac
+    - $ xcode-select --install
+2. Debian based
+    - $ apt-get update -q && apt-get install -qy g++ python-dev
+3. Fedora based
+    - $ yum install -qy gcc-c++ python-devel
+4. Alpine
+    - $ apk update && apk add g++ python-dev
+
+## Serverless and PaaS deployments
+
+If you are running your application on a Serverless or PaaS (Platform as a Service), you must build your package in an environment similar to those used in production. 
+If you are running on a Windows or Mac machine (or using an incompatible Linux distribution) you may encounter some issues here.
+
+Many Serverless frameworks (such as AWS sam) have built-in support for it and will work out of the box.
+
+If you need to set up your own build, we recommend using Docker, with a command line such as:
+```bash
+    $ docker run -it -v `pwd`:`pwd` -w `pwd` python:2.7 pip install -t lib
+```
+
+For more information check out this blog post: https://www.rookout.com/3_min_hack_for_building_local_native_extensions/
+
 
 ## Examples
 
@@ -78,4 +102,4 @@ Check out the following deployment examples:
 - [AWS Lambda + Chalice](https://github.com/Rookout/deployment-examples/tree/master/python-aws-chalice)
 - [AWS Lambda + serverless framework ](https://github.com/Rookout/deployment-examples/tree/master/python-aws-serverlessframework)
 
-Or visit [our GitHub repository](https://github.com/Rookout/deployment-examples) for more.
+Or visit [our GitHub repository](https://github.com/Rookout/deployment-examples) for more deployment examples.


### PR DESCRIPTION
Still missing, will be handled in #2356 :
-Rookout API for all three languages
-Lambda info for Python and Node
-Node dependencies
-Maven snippet for Java setup