### PR TITLE
RK-4452 - Capitalized all the Slack mentions

### DIFF
--- a/docs/collaboration.md
+++ b/docs/collaboration.md
@@ -7,9 +7,9 @@ Leverage the power of Non-Breaking Breakpoints by connecting with your existing 
 
 ## Slack
 
-In rookout, as you debug your app, you can share the data you extract using slack.
-On the message there is a share button which has an authorize slack app button.
-To enable the use of Rookout’s slack integration for message sharing, simply authorize the app by pressing the button and authorizing Rookout-Share in the opened window.
+In rookout, as you debug your app, you can share the data you extract using Slack.
+On the message there is a share button which has an authorize Slack app button.
+To enable the use of Rookout’s Slack integration for message sharing, simply authorize the app by pressing the button and authorizing Rookout-Share in the opened window.
 There is no need to install Rookout in your Slack workspace.
 Rookout will send the message from your user straight to your chosen channel.
 


### PR DESCRIPTION
According to the Slack brand guidelines all the mentions of Slack must be with a capital S