### PR TITLE
RK-5304 - typo fix in node connectivity test

### DIFF
--- a/docs/node-setup.md
+++ b/docs/node-setup.md
@@ -92,7 +92,7 @@ The callback is executed when the method finishes.
 
 To make sure the SDK was properly installed and test your configuration (environment variables only), run the following command:
 ```bash
-./node_modules/.bin/rookout_check
+./node_modules/.bin/rookout-check
 ```
 
 ## Supported Versions


### PR DESCRIPTION
It looks like this should be a dash instead of an underscore now.  rookout-check instead of rookout_check