### PR TITLE
RK-6552 - Fix path to rook.jar in -javaagent options

### DIFF
--- a/docs/jvm-setup.md
+++ b/docs/jvm-setup.md
@@ -26,7 +26,7 @@ Simply add the Rookout SDK as a Java Agent to your environment:
 <!--Environment Variable-->
 ```bash
 # Add the Rookout Java Agent to your application using an environment variable
-export JAVA_TOOL_OPTIONS="-javaagent:(pwd)/rook.jar -DROOKOUT_TOKEN=[Your Rookout Token]"
+export JAVA_TOOL_OPTIONS="-javaagent:$(pwd)/rook.jar -DROOKOUT_TOKEN=[Your Rookout Token]"
 
 # Optional, see Labels section below Projects
 export ROOKOUT_LABELS=env:dev
@@ -34,7 +34,7 @@ export ROOKOUT_LABELS=env:dev
 <!--Command Line-->
 ```bash
 # Add the Java Agent, token and the labels to your application using command line
-java -javaagent:(pwd)/rook.jar MyClass -DROOKOUT_TOKEN=[Your Rookout Token] -DROOKOUT_LABELS=env:dev
+java -javaagent:$(pwd)/rook.jar MyClass -DROOKOUT_TOKEN=[Your Rookout Token] -DROOKOUT_LABELS=env:dev
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 <div class="rookout-org-info"></div>


### PR DESCRIPTION
A minor fix to the `-javaagent` options.

--

###  Wizard issues

From #296 it looks like the wizard may also need to be updated, but I wasn't sure where the source code was, so I wanted to let you know here there are also a couple of issues with the content of the wizard too:

* the double quotes appear as `”` instead of `"`
* the `JAVA_TOOL_OPTIONS` environment variable includes a line return, which may not be desirable:

``` 
export JAVA_TOOL_OPTIONS=“-javaagent:(pwd)/rook.jar 
 -DROOKOUT_TOKEN=< ... token ... >”
```

I think this should probably be a single line, regular quotes (`"`) and `$(pwd)` instead of `(pwd)`, i.e.:

```
export JAVA_TOOL_OPTIONS="-javaagent:$(pwd)/rook.jar -DROOKOUT_TOKEN=< ... token ... >"
```