### PR TITLE
RK-6877 - dotnet code snippet for the labels page

### DIFF
--- a/docs/projects-labels.md
+++ b/docs/projects-labels.md
@@ -38,7 +38,15 @@ rook.start({
 ```bash
 # Export your labels as an environment variable
 export ROOKOUT_LABELS=service:service3,env:dev
-
+```
+<!--.NET-->
+```cs
+Rook.RookOptions options = new Rook.RookOptions() 
+    {
+        token = "[Your Rookout Token]",
+        labels = new Dictionary<string, string> { { "service", "service#3" }, { "env", "dev" } }
+    };
+Rook.API.Start(options);
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 <div class="rookout-org-info"></div>


### PR DESCRIPTION
noticed there's no example for dotnet in the code snippets of the labels page, so I added one.