### PR TITLE
RK-7304 - Conditions rewriting

### DIFF
--- a/docs/breakpoints-conditional.md
+++ b/docs/breakpoints-conditional.md
@@ -6,8 +6,7 @@ Conditional breakpoints allows you to limit your data collection from a code sni
 
 Add a Condition by right click on a breakpoint and choose the 'Edit' option. A right pane will open up, click on the arrow next to 'Condition', write the expression you wish to check and click 'Set' at the bottom of the pane.
 
-<iframe style="margin: 20px 0 0 0" width="560" height="315" src="https://www.youtube.com/watch?v=IkuvAH52PVA&feature=youtu.be&ab_channel=Rookout?rel=0" frameborder="0" allow="autoplay; encrypted-media;" allowfullscreen></iframe>
-
+<iframe width="560" height="315" src="https://www.youtube.com/embed/IkuvAH52PVA" frameborder="0" allow="autoplay; encrypted-media;" allowfullscreen></iframe>
 ### Rookout provides two types of conditions:
 - Simple - compare the value of one or two variables.
 - Advanced - define a complex condition using logical parameters (use "&&" for AND statement,  "||" for OR statement, "(" and ")" for encapsulation).

--- a/docs/breakpoints-conditional.md
+++ b/docs/breakpoints-conditional.md
@@ -2,22 +2,15 @@
 id: breakpoints-conditional
 title: Conditional breakpoints
 ---
+Conditional breakpoints allows you to limit your data collection from a code snippet to only when the defined expression evaluates as true.
 
+Add a Condition by right click on a breakpoint and choose the 'Edit' option. A right pane will open up, click on the arrow next to 'Condition', write the expression you wish to check and click 'Set' at the bottom of the pane.
 
-Conditional breakpoints limit data collection from a code snippet to cases when the defined expression evaluates as true.
-
-<iframe style="margin: 20px 0 0 0" width="560" height="315" src="https://www.youtube.com/embed/iua-P2o6U9w" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
-
+<iframe style="margin: 20px 0 0 0" width="560" height="315" src="https://www.youtube.com/watch?v=IkuvAH52PVA&feature=youtu.be&ab_channel=Rookout?rel=0" frameborder="0" allow="autoplay; encrypted-media;" allowfullscreen></iframe>
 
 ### Rookout provides two types of conditions:
 - Simple - compare the value of one or two variables.
 - Advanced - define a complex condition using logical parameters (use "&&" for AND statement,  "||" for OR statement, "(" and ")" for encapsulation).
-
-### Add and Edit Conditional breakpoints:
-- Set a breakpoint.
-- Right click on the new breakpoint, and then select 'Edit' in the menu.
-- Choose condition type - Simple or Advanced.
-- Set your condition.
 
 ### Advanced conditions - supported operators and functions:
 
@@ -36,8 +29,15 @@ Conditional breakpoints limit data collection from a code snippet to cases when 
 | `[]` | `arr[4]!=4`, `dict['a']!=4`  | Set conditions regarding to a specific sequence’s element - list, dict etc. |
 | `size` | `arr.size() >= 32` | Use size instead of len or length on any platform |
 
+
+* Evaluating functions are currently not supported in conditions. 
+
 ### Time-To-Live:
 
 Seting time-to-live on a breakpoint places limits on the life span of the breakpoint. The breakpoint will disable automatically past the configured limit
 
 <iframe src="https://player.vimeo.com/video/373492033?color=af6bd6&title=0&byline=0&portrait=0" width="640" height="400" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+
+**Keep in mind:** 
+1. The supported syntax may be different from your developing language and it can be confusing - just make sure you use the supported operators above.  
+2. A condition can be invalid due to typos and wrong variables, check that your variables written correctly. 

--- a/docs/breakpoints-conditional.md
+++ b/docs/breakpoints-conditional.md
@@ -2,7 +2,6 @@
 id: breakpoints-conditional
 title: Conditional breakpoints
 ---
-
 A large amount of messages in a Debug Session can be confusing at times, especially when trying to solve a specific bug or find a certain use case. 
 For a faster debugging experience - refine data and filter out irrelevant messages by setting a Conditional Breakpoint. 
 

--- a/docs/breakpoints-conditional.md
+++ b/docs/breakpoints-conditional.md
@@ -2,7 +2,12 @@
 id: breakpoints-conditional
 title: Conditional breakpoints
 ---
+
+A large amount of messages in a Debug Session can be confusing at times, especially when trying to solve a specific bug or find a certain use case. 
+For a faster debugging experience - refine data and filter out irrelevant messages by setting a Conditional Breakpoint. 
+
 Conditional breakpoints allows you to limit your data collection from a code snippet to only when the defined expression evaluates as true.
+This makes it possible to debug specific scenarios, and limit your messages to   
 
 Add a Condition by right click on a breakpoint and choose the 'Edit' option. A right pane will open up, click on the arrow next to 'Condition', write the expression you wish to check and click 'Set' at the bottom of the pane.
 
@@ -12,7 +17,7 @@ Add a Condition by right click on a breakpoint and choose the 'Edit' option. A r
 - Simple - compare the value of one or two variables.
 - Advanced - define a complex condition using logical parameters (use "&&" for AND statement,  "||" for OR statement, "(" and ")" for encapsulation).
 
-### Advanced conditions - supported operators and functions:
+`### Advanced conditions - supported operators and functions:
 
 | Operator  | Example  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description |
 | ------------ | ----------------------- | ------------- |

--- a/docs/breakpoints-conditional.md
+++ b/docs/breakpoints-conditional.md
@@ -2,6 +2,7 @@
 id: breakpoints-conditional
 title: Conditional breakpoints
 ---
+
 A large amount of messages in a Debug Session can be confusing at times, especially when trying to solve a specific bug or find a certain use case. 
 For a faster debugging experience - refine data and filter out irrelevant messages by setting a Conditional Breakpoint. 
 

--- a/docs/breakpoints-conditional.md
+++ b/docs/breakpoints-conditional.md
@@ -7,6 +7,7 @@ Conditional breakpoints allows you to limit your data collection from a code sni
 Add a Condition by right click on a breakpoint and choose the 'Edit' option. A right pane will open up, click on the arrow next to 'Condition', write the expression you wish to check and click 'Set' at the bottom of the pane.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/IkuvAH52PVA" frameborder="0" allow="autoplay; encrypted-media;" allowfullscreen></iframe>
+
 ### Rookout provides two types of conditions:
 - Simple - compare the value of one or two variables.
 - Advanced - define a complex condition using logical parameters (use "&&" for AND statement,  "||" for OR statement, "(" and ")" for encapsulation).


### PR DESCRIPTION
We hear repeating feedback from users regarding Conditions settings:
״I don’t understand the condition syntax״ (Rookout supports different lango for conditions)
״I don’t understand when I have a typo (in vars) in my conditions.
״Documentation didn’t help me to understand my error / doesn't match the UI״  

To improve our user's experience we decide to rewrite the documentation and clarify a few pain points:
1.Which syntax is supported
2.Which type of variables are supported in conditions
3.Different reasons for condition set up to fail (typo, wrong syntax, etc...)
4. Explanations about differences between the languages Rookouts support and other languages  


