### PR TITLE
RK-8376 - pip already there, easy_install is deprecated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ references:
      command: |
        mkdir -p ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
        sudo apt-get install python3-setuptools python3-dev build-essential -qy
-       sudo easy_install pip
        git clone git@github.com:Rookout/build_tools.git
        cd build_tools
        pip install -r requirements.txt --user


### PR DESCRIPTION
getting sudo: easy_install: command not found in circleci
pip is already installed, so no need for it
