### PR TITLE
RK-11052 - SDK setup pages improvements

### DIFF
--- a/docs/dotnet-setup.md
+++ b/docs/dotnet-setup.md
@@ -1,21 +1,27 @@
 ---
 id: dotnet-setup
-title: .NET SDK Instrumentation
+title: .NET SDK
 sidebar_label: .NET
 ---
 
-This page will dive into the nitty gritty details on installing Rookout under various configurations.  
-If you are encountering any difficulties with deploying Rookout, this is the place to look.
+This page dives into the nitty-gritty details on installing Rookout under various configurations.  
+If you encounter difficulties with deploying Rookout, this is the place to look.
 
-## .NET
+## Installation
 
-The [.NET SDK](https://www.nuget.org/packages/Rookout) provides the ability to fetch debug data from a running application in real time.  
+The [.NET SDK](https://www.nuget.org/packages/Rookout) provides the ability to fetch debug data from a running application in real-time.  
 
 It can easily be installed as a [NuGet package](https://www.nuget.org/packages/Rookout).
 
+## Supported Languages
+
+The following languages are currently supported by the .NET SDK: C#, VB.NET, and F#.
+
+If you use a language that is not mentioned above, please let us know at {@inject: supportEmail}.
+
 ## Setup
 
-Start the SDK within your application, by adding the following to your *main* method or your application's entry point:
+Start the SDK within your application by adding the following to your *main* method or your application's entry point:
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--C#-->
@@ -172,10 +178,6 @@ Rook.API.LoadAssembly(Assembly a, byte[] pdb, byte[] assembly)
 | **.NET Framework**  | 4.5, 4.6, 4.7, 4.8    |
 | **.NET Core**       | 2.1, 2.2, 3.0, 3.1    |
 | **.NET**            | 5.0                   |
-
-## Supported Languages
-
-The following languages are officially supported: C#, VB.NET and F#.
 
 ## IIS support
 

--- a/docs/go-setup.md
+++ b/docs/go-setup.md
@@ -1,27 +1,16 @@
 ---
 id: go-setup
-title: Go SDK Instrumentation
+title: Go SDK
 sidebar_label: Go
 ---
 
-This page will dive into the nitty gritty details on installing Rookout under various configurations.  
-If you are encountering any difficulties with deploying Rookout, this is the place to look.
+---
 
-## Setup
+*Please note that the Go SDK is currently not generally available. We are rolling it out gradually to keep up with the high demand.*
 
-Start the SDK within your application:
-```go
-import (
-	rookout "github.com/Rookout/GoRook"
-)
+*Please [Contact us](https://www.rookout.com/company/contact) if you would like to get access.*
 
-func main() {
-	_ = rookout.Start(map[string]string{"env": "prod"})
-}
-```
-<div class="rookout-org-info"></div>
-
-The `Start` function can get a map of labels as an argument.
+---
 
 ## SDK API
 
@@ -33,8 +22,8 @@ Start(labels);
 
 The `Start` method is used to initialize the SDK.
 
-| Argument &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Environment Variable &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Default Value | Description |
-| ------------ | ----------------------- | ------------- | ----------- |
+| Argument | Environment Variable | Default Value | Description |
+| --- | --- | --- | --- |
 | - | `ROOKOUT_TOKEN` | None | The Rookout token for your organization. Should be left empty if you are using a Rookout ETL Controller |
 | `labels` | - | {} | A map of key:value labels for your application instances |
 | - | `ROOKOUT_CONTROLLER_HOST` | None | If you are using a Rookout ETL Controller, this is the hostname for it |

--- a/docs/jvm-setup.md
+++ b/docs/jvm-setup.md
@@ -1,13 +1,11 @@
 ---
 id: jvm-setup
-title: JVM SDK Instrumentation
+title: JVM SDK
 sidebar_label: JVM
 ---
 
-This page will dive into the nitty gritty details on installing Rookout under various configurations.  
-If you are encountering any difficulties with deploying Rookout, this is the place to look.
-
-
+This page dives into the nitty-gritty details on installing Rookout under various configurations.  
+If you encounter difficulties with deploying Rookout, this is the place to look.
 
 ## JVM
 
@@ -16,6 +14,12 @@ It can be download directly to the target system by running the following comman
 ```bash
 curl -L "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.rookout&a=rook&v=LATEST" -o rook.jar
 ```
+
+## Supported Languages
+
+The following languages are currently supported by the JVM SDK: Java, Scala, Kotlin, Groovy, ColdFusion, and Clojure.
+
+If you use a language that is not mentioned above, please let us know at {@inject: supportEmail}.
 
 ## Setup
 
@@ -164,9 +168,7 @@ ROOKOUT_TARGET_PID=1234 java -jar rook.jar
 
 The following Java versions are supported: 7 (7u111+), 8 (8u74+), 11 (11u4+), 13, 17.
 
-The following languages are supported: Java, Scala, Kotlin, Groovy, ColdFusion, and Clojure.
-
-If your version or language is not mentioned above, please let us know at {@inject: supportEmail}.
+If your version is not mentioned above, please let us know at {@inject: supportEmail}.
 
 ## Dependencies
 

--- a/docs/node-setup.md
+++ b/docs/node-setup.md
@@ -1,6 +1,6 @@
 ---
 id: node-setup
-title: Node.js SDK Instrumentation
+title: Node.js SDK
 sidebar_label: Node.js
 ---
 

--- a/docs/python-setup.md
+++ b/docs/python-setup.md
@@ -1,6 +1,6 @@
 ---
 id: python-setup
-title: Python SDK Instrumentation
+title: Python SDK
 sidebar_label: Python
 ---
 

--- a/docs/ruby-setup.md
+++ b/docs/ruby-setup.md
@@ -1,6 +1,6 @@
 ---
 id: ruby-setup
-title: Ruby SDK Instrumentation
+title: Ruby SDK
 sidebar_label: Ruby
 ---
 


### PR DESCRIPTION
Go SDK not available message.
Changed title of SDK pages.
Moved the .NET and JVM supported languages section to the top.