### PR TITLE
RK-11248 - Remove GIT_COMMIT and improve source info

### DIFF
--- a/docs/dotnet-setup.md
+++ b/docs/dotnet-setup.md
@@ -169,7 +169,10 @@ Use the environment variables or start parameters as described above in the API 
 
 ### Git Folder
 
-If the .git folder is present at the root of your project, and no environment variables / start parameters are set, then the source information will be taken from it.
+Rookout gets the source information from the .git folder if both of the following apply:
+
+1. The .git folder is present at any of the parent directories of where the application is running (searching up the tree).
+2. No environment variables or start parameters are set for source information.
 
 ### MSBuildGitHash Package
 

--- a/docs/jvm-setup.md
+++ b/docs/jvm-setup.md
@@ -132,6 +132,21 @@ jar {
 
 ## Source information
 
+To enable automatic source fetching, information about the source control must be specified.
+
+### Environment Variables or Start Parameters
+
+Use the environment variables or start parameters as described above in the API section. 
+
+### Git Folder
+
+Rookout gets the source information from the .git folder if both of the following apply:
+
+1. The .git folder is present at any of the parent directories of where the application is running (searching up the tree).
+2. No environment variables or start parameters are set for source information.
+
+### Multiple Sources
+
 Use the environment variable `ROOKOUT_SOURCES` to initialize the SDK with information about the sources used in your application.
 
 ROOKOUT_SOURCES is a semicolon-separated list with either a source control repository and revision information, or a path on the local filesystem to a JAR file.
@@ -141,6 +156,7 @@ Example
 ROOKOUT_SOURCES=https://github.com/Rookout/Rookout#afe123;/path/to/lib.jar
 ```
 
+### Jar File
 To load source information from a jar file, you need to add the following attributes to the JAR manifest:
 
 `Rookout-Repository`: Repository URL

--- a/docs/node-setup.md
+++ b/docs/node-setup.md
@@ -80,18 +80,6 @@ To make sure the SDK was properly installed and test your configuration (environ
 ```bash
 ./node_modules/.bin/rookout-check
 ```
-## Source information
-
-Use the environment variable `ROOKOUT_SOURCES` to initialize the SDK with information about the sources used in your application.
-
-ROOKOUT_SOURCES is a semicolon-separated list with a source control repository and revision information. 
-This will allow Rookout to automatically fetch your application's source code from the right revision, and also additional dependencies' sources.
-When using Git the repository is a URL (remote origin) and the revision is a full commit hash or a branch name.
-
-For example let's say I use https://github.com/Rookout/tutorial-nodejs with the commit 2f79053d7bc7c9c9561a30dda202b3dcd2b72b90 and I use the Lodash package (https://github.com/lodash/lodash) from its master branch:
-```
-ROOKOUT_SOURCES=https://github.com/Rookout/tutorial-nodejs#cf85c4e0365d8082ca2e1af63ca8b5b436a13909;https://github.com/lodash/lodash#master
-```
 
 ## Transpiling and Source Maps
 Transpiling your JavaScript/TypeScript on the fly (using [babel-node](https://babeljs.io/docs/en/babel-node) or a similar tool), Rookout debugging will work out of the box.
@@ -131,12 +119,33 @@ The additional step will make sure the source maps end up in the right place:
  }
 ```
 
-## Source Code Detection
+## Source information
 
-The NodeJS SDK supports detecting the existing source code commit in the following methods, in descending order of priority:
-1. If the environment variable “ROOKOUT_COMMIT” exists, use it.
-2. If the environment variable “ROOKOUT_GIT” exists, search for the configuration of the “.git” folder and use its head.
-3. If the main application is running from within a Git repository, use its head. 
+To enable automatic source fetching, information about the source control must be specified.
+
+### Environment Variables or Start Parameters
+
+Use the environment variables or start parameters as described above in the API section. 
+
+### Git Folder
+
+Rookout gets the source information from the .git folder if both of the following apply:
+
+1. The .git folder is present at any of the parent directories of where the application is running (searching up the tree).
+2. No environment variables or start parameters are set for source information.
+
+### Multiple Sources
+
+Use the environment variable `ROOKOUT_SOURCES` to initialize the SDK with information about the sources used in your application.
+
+ROOKOUT_SOURCES is a semicolon-separated list with a source control repository and revision information. 
+This will allow Rookout to automatically fetch your application's source code from the right revision, and also additional dependencies' sources.
+When using Git the repository is a URL (remote origin) and the revision is a full commit hash or a branch name.
+
+For example let's say I use https://github.com/Rookout/tutorial-nodejs with the commit 2f79053d7bc7c9c9561a30dda202b3dcd2b72b90 and I use the Lodash package (https://github.com/lodash/lodash) from its master branch:
+```
+ROOKOUT_SOURCES=https://github.com/Rookout/tutorial-nodejs#cf85c4e0365d8082ca2e1af63ca8b5b436a13909;https://github.com/lodash/lodash#master
+```
 
 ## Supported Versions
 

--- a/docs/python-setup.md
+++ b/docs/python-setup.md
@@ -93,12 +93,20 @@ To make sure the SDK was properly installed in your Python (virtual) environment
 ```bash
 python -m rook
 ```
-## Source Commit Detection
+## Source information
 
-The Python SDK supports detecting the existing source code commit in the following methods, in descending order of priority:
-1. If the environment variable “ROOKOUT_COMMIT” exists, use it.
-2. If the environment variable “ROOKOUT_GIT” exists, search for the configuration of the “.git” folder and use its head.
-3. If the main application is running from within a Git repository, use its head. 
+To enable automatic source fetching, information about the source control must be specified.
+
+### Environment Variables or Start Parameters
+
+Use the environment variables or start parameters as described above in the API section. 
+
+### Git Folder
+
+Rookout gets the source information from the .git folder if both of the following apply:
+
+1. The .git folder is present at any of the parent directories of where the application is running (searching up the tree).
+2. No environment variables or start parameters are set for source information.
 
 ## Supported Python versions
 


### PR DESCRIPTION
Removed GIT_COMMIT (need to make sure we have it documented internally)

Aligned the Source Info sections of some SDKs