### PR TITLE
RK-12979 - RCS-676 - Update ruby-setup.md

### DIFF
--- a/docs/ruby-setup.md
+++ b/docs/ruby-setup.md
@@ -142,4 +142,4 @@ If you need to set up your own build, we recommend using Docker, with a command 
 docker run -v `pwd`:`pwd` -w `pwd` -i -t lambci/lambda:build-ruby2.7 pip install -r requirements.txt
 ```
 
-For more information check out this blog post: https://www.rookout.com/3_min_hack_for_building_local_native_extensions/
+For more information check out this blog post: https://www.rookout.com/blog/3-min-hack-for-locally-building-a-native-extension/


### PR DESCRIPTION
#clicks on the "For more info..." link in our Ruby SDK setup documentation and receives an error message 404-Page not found.
