### PR TITLE
RK-13094 - Remove broken link to FAQ

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -128,8 +128,3 @@ When a non-breaking breakpoint is triggered, you should see messages in the mess
 For more information on Non-Breaking Breakpoints, refer to this page: [Debug Session Setup](debug-session-setup.md)
 
 If you encounter an issue while setting a breakpoint, refer to this page for information on breakpoint statuses: [Breakpoint Status](breakpoints-status.md)
-
-## Frequently asked questions
-
-For more information, take a look at the [Rookout FAQ page](https://www.rookout.com/faq).
-


### PR DESCRIPTION
There is a broken link in the docs to https://www.rookout.com/faq/

If we intend to support FAQs I'll revert this change as soon as the page is live again. 