### PR TITLE
Making the typescript sourcemaps less ambiguous

### DIFF
--- a/docs/node-setup.mdx
+++ b/docs/node-setup.mdx
@@ -119,7 +119,7 @@ If your application's code is being transpiled or bundled, you must include the 
 
 -   [**Webpack**](https://webpack.js.org/) - use either the `inline-source-map` or `source-map` values for the `devtool` option in the webpack config file ([reference](https://webpack.js.org/configuration/devtool)).
 -   [**Babel**](https://babeljs.io/) - use either the `"inline"`, `"both"` or `true` values for the `sourceMaps` option in the Babel config file ([reference](https://babeljs.io/docs/en/options#sourcemaps)).
--   [**TypeScript**](https://www.typescriptlang.org/) - add either `"inlineSourceMap": true` or `"sourceMap": true` as well as `"inlineSources": true` in the TypeScript config file ([reference](https://www.typescriptlang.org/tsconfig#inlineSourceMap)).
+-   [**TypeScript**](https://www.typescriptlang.org/) - add either `"inlineSourceMap": true` or `"sourceMap": true` to the TypeScript config file, and also add `"inlineSources": true`. ([reference](https://www.typescriptlang.org/tsconfig#inlineSourceMap)).
 -   [**CoffeeScript**](https://coffeescript.org/) - pass either the `-M` (inline) or `-m` flags to the `coffee` CLI tool ([reference](https://coffeescript.org/#usage)).
 
 ### Bundling tools


### PR DESCRIPTION
I just found out that the wording here can be a bit ambiguous and changed it to be more clear.