### PR TITLE
RK-19172 - debian-bookworm-libc

### DIFF
--- a/docs/go-setup.mdx
+++ b/docs/go-setup.mdx
@@ -113,8 +113,8 @@ Depending on your OS, you may need to install additional dependencies:
 <TabItem value="debian">    
 
 ```bash 
-
-apt update && apt install -y libffi-dev zlib1g-dev libedit-dev libc++-11-dev libc++abi-11-dev
+# Debian 
+apt update && apt install -y libffi-dev zlib1g-dev libedit-dev libc++-13-dev libc++abi-13-dev
 
 ```
 </TabItem>

--- a/docs/go-setup.mdx
+++ b/docs/go-setup.mdx
@@ -113,7 +113,7 @@ Depending on your OS, you may need to install additional dependencies:
 <TabItem value="debian">    
 
 ```bash 
-# Debian 
+
 apt update && apt install -y libffi-dev zlib1g-dev libedit-dev libc++-13-dev libc++abi-13-dev
 
 ```


### PR DESCRIPTION
libc++-11 and libc++abi-11 is outdated for latest stable Debian "bookworm"
https://packages.debian.org/search?searchon=names&keywords=libc%2B%2B
https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=libc%2B%2Babi