### PR TITLE
RK-19999 - Update go-setup.mdx

### DIFF
--- a/docs/go-setup.mdx
+++ b/docs/go-setup.mdx
@@ -122,7 +122,7 @@ apt update && apt install -y libffi-dev zlib1g-dev libedit-dev libc++-13-dev lib
 
 ```bash 
 
-apk add —-no-cache gcc musl-dev zlib-static build-base
+apk add --no-cache gcc musl-dev zlib-static build-base
 
 ```
 </TabItem>


### PR DESCRIPTION
the two hyphen signs next to the "no -cache" are not the same (one of them appears different) causing an error